### PR TITLE
Sintaxis antigua para la descarga

### DIFF
--- a/src/Launcher/downloader.js
+++ b/src/Launcher/downloader.js
@@ -5,36 +5,36 @@ const librariesDownloader = require('../Downloaders/librariesDownloader.js');
 const assetsDownloader = require('../Downloaders/assetsDownloader.js');
 
 /**
- *
- * @param {string} root Directorio principal - './minecraft'
- * @param {string} version Version a Descargar - '1.16.5'
- * @param {string} version Tipo de Version a Descargar - 'release' o 'snapshot'
- */
-module.exports = async function downloadMinecraft({ root, version, type }) {
-  let data = { root: root, version: version, type: type };
+*
+* @param {string} version Version a Descargar - '1.16.5'
+* @param {string} root Directorio principal - './minecraft' 
+* @param {string} type Tipo de Version a Descargar - 'release' o 'snapshot'
+*/
+module.exports = async function downloadMinecraft(version, root, type) {
+ let data = { root: root, version: version, type: type };
 
-  console.log(`Empezando la descarga de Minecraft v${version}`);
+ console.log(`Empezando la descarga de Minecraft v${version}`);
 
-  let versionData = JSON.parse(JSON.parse(await versionDownloader(data)));
+ let versionData = JSON.parse(JSON.parse(await versionDownloader(data)));
 
-  clientDownloader({
-    ...data,
-    client: versionData.downloads.client.url,
-  });
+ clientDownloader({
+   ...data,
+   client: versionData.downloads.client.url,
+ });
 
-  nativesDownloader({
-    ...data,
-    libraries: versionData.libraries,
-  });
+ nativesDownloader({
+   ...data,
+   libraries: versionData.libraries,
+ });
 
-  librariesDownloader({
-    ...data,
-    libraries: versionData.libraries,
-  });
+ librariesDownloader({
+   ...data,
+   libraries: versionData.libraries,
+ });
 
-  assetsDownloader({
-    ...data,
-    asset: versionData.assetIndex.url,
-    totalSize: versionData.assetIndex.totalSize,
-  });
+ assetsDownloader({
+   ...data,
+   asset: versionData.assetIndex.url,
+   totalSize: versionData.assetIndex.totalSize,
+ });
 };


### PR DESCRIPTION
Antes:
downloadMinecraft({
  root: './minecraft', // RUTA DEL JUEGO
  version: '1.8.8', // VERSION A DESCARGAR
  type: 'release', // TIPO DE VERSION (release - snapshot)
});

Ahora:
downloadMinecraft('1.16.5', './minecraft', 'release');